### PR TITLE
fix: group wont sending because validating (-)

### DIFF
--- a/src/Utils/phone-to-jid.ts
+++ b/src/Utils/phone-to-jid.ts
@@ -17,29 +17,27 @@ export const phoneToJid = ({
   if (!to) throw new WhatsappError('parameter "to" is required');
   let number = to.toString().replace(/\s|\+/g, "");
 
-  // Jika sudah group JID (ada @g.us), biarkan tanda minus
+  // if any group JID (@g.us), leave the (-) return it as is
   if (number.endsWith("@g.us")) {
     return number;
   }
 
-  // Pattern group JID: angka-angka-tanda minus-angka-angka (misal: 6282170389181-1610338502)
+  // Pattern group JID: // 1234567890-1234567890 = group JID
   const isGroupJidFormat = isGroup && /^\d+-\d+$/.test(number);
 
-  // Kalau bukan group JID, hapus tanda minus
+  // if not JID group, remove any (-) minus characters
   if (!isGroupJidFormat) {
     number = number.replace(/-/g, "");
   }
 
-  // Tambahkan suffix JID
+  // Add suffix if not exists
   if (isGroup) {
     if (!number.endsWith("@g.us")) number = number + "@g.us";
   } else {
+    // remove any spaces or plus characters
+    // remove all unnecessary logic code and make it look efficient
+    number = number.replace(/\s|\+/gim, "");
     if (!number.endsWith("@s.whatsapp.net"))
-    number = number.replace(/\s|\+/gim, "");
-    if (!number.includes("@g.us")) number = number + "@g.us";
-  } else {
-    number = number.replace(/\s|\+/gim, "");
-    if (!number.includes("@s.whatsapp.net"))
       number = number + "@s.whatsapp.net";
   }
 


### PR DESCRIPTION
1. Modified the phoneToJid function to properly handle hyphenated phone numbers
2. Added specific logic to detect and preserve group JID formats (numbers-hyphen-numbers pattern)
3. Only removes hyphens for regular phone numbers, keeping them intact for group identifiers
4. Ensures proper suffix application (@g.us for groups, @s.whatsapp.net for individual contacts)