### PR TITLE
fix: improve session ID extraction from credentials directory

### DIFF
--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -300,7 +300,7 @@ export const loadSessionsFromStorage = () => {
       throw err;
     }
     for (const dir of dirs) {
-      const sessionId = dir.split("_")[0];
+      const sessionId = dir.slice(0, dir.lastIndexOf('_'));
       if (!shouldLoadSession(sessionId)) continue;
       startSession(sessionId);
     }


### PR DESCRIPTION
The change correctly handles session IDs that contain underscore characters by using lastIndexOf('_') to find the '_credentials' suffix. This ensures that session IDs like 'my_test' are properly loaded from 'my_test_credentials' directory.