### PR TITLE
fix(socket): correct event listener callback handling

### DIFF
--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -111,7 +111,7 @@ export const startSession = async (
             messageStatus: parseMessageStatusCodeToReadable(msg.update.status!),
             ...msg,
           };
-          callback.get(CALLBACK_KEY.ON_MESSAGE_UPDATED)?.(sessionId, data);
+          callback.get(CALLBACK_KEY.ON_MESSAGE_UPDATED)?.(data);
           options.onMessageUpdated?.(data);
         }
         if (events["messages.upsert"]) {
@@ -217,7 +217,7 @@ export const startSessionWithPairingCode = async (
             messageStatus: parseMessageStatusCodeToReadable(msg.update.status!),
             ...msg,
           };
-          callback.get(CALLBACK_KEY.ON_MESSAGE_UPDATED)?.(sessionId, data);
+          callback.get(CALLBACK_KEY.ON_MESSAGE_UPDATED)?.( data);
         }
         if (events["messages.upsert"]) {
           const msg = events["messages.upsert"]
@@ -338,5 +338,5 @@ export const onMessageUpdate = (listener: (data: MessageUpdated) => any) => {
 export const onPairingCode = (
   listener: (sessionId: string, code: string) => any
 ) => {
-  callback.set(CALLBACK_KEY.ON_MESSAGE_UPDATED, listener);
+  callback.set(CALLBACK_KEY.ON_PAIRING_CODE, listener);
 };


### PR DESCRIPTION
This commit resolves two bugs related to event listener callbacks in the socket handler:

- **`onPairingCode` listener** Was incorrectly using the `ON_MESSAGE_UPDATED` key, which caused it to overwrite the `onMessageUpdate` listener.

- **`onMessageUpdate` listener** Was being called with two arguments (`sessionId, data`) instead of the single expected `data` object, causing a `TypeError` for consumers.

Both issues have been corrected to ensure event listeners work as intended.