### PR TITLE
Fix crash when "msg.message" is undefined

### DIFF
--- a/src/Whatsapp/Whatsapp.ts
+++ b/src/Whatsapp/Whatsapp.ts
@@ -247,7 +247,7 @@ export class Whatsapp {
           if (events["messages.upsert"]) {
             const msg = events["messages.upsert"]
               .messages?.[0] as unknown as MessageReceived;
-            if (msg.message.protocolMessage) {
+            if (msg?.message?.protocolMessage) {
               // ignore history sync messages
               return;
             }
@@ -395,7 +395,7 @@ export class Whatsapp {
           if (events["messages.upsert"]) {
             const msg = events["messages.upsert"]
               .messages?.[0] as unknown as MessageReceived;
-            if (msg.message.protocolMessage) {
+            if (msg?.message?.protocolMessage) {
               // ignore history sync messages
               return;
             }


### PR DESCRIPTION
Prevent runtime error by safely checking "protocolMessage" using optional chaining, since some Baileys message events may not include a "message" payload.